### PR TITLE
Retrieve token on each request

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@auth0/auth0-react": "^2.2.4",
+    "@auth0/auth0-spa-js": "^2.1.3",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@fontsource/roboto": "^5.0.13",
@@ -72,6 +73,7 @@
     "@types/qs": "^6.9.15",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/react-i18next": "^8.1.0",
     "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/eslint-plugin": "^8.0.1",
     "@typescript-eslint/parser": "^8.0.1",

--- a/src/auth0/InfraInterceptors.tsx
+++ b/src/auth0/InfraInterceptors.tsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import qs from 'qs';
-import { useJwtFromCookie } from '../Redux/hooks';
+import { getTokenSilently } from './authUtils';
 
 const InfraInstance = axios.create({
   baseURL: import.meta.env.VITE_INFRA_SERVICE_URL,
@@ -8,13 +8,11 @@ const InfraInstance = axios.create({
 });
 
 InfraInstance.interceptors.request.use(
-  (config) => {
-    const token = useJwtFromCookie('accessToken');
-
+  async (config) => {
+    const token = await getTokenSilently();
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
-
     return config;
   },
   (error) => {

--- a/src/auth0/WorkersInterceptors.tsx
+++ b/src/auth0/WorkersInterceptors.tsx
@@ -1,20 +1,18 @@
 import axios from 'axios';
 import qs from 'qs';
-import { useJwtFromCookie } from '../Redux/hooks';
-import { useTranslation } from 'react-i18next';
+import { getTokenSilently } from './authUtils';
 
 const workerInstance = axios.create({
   baseURL: import.meta.env.VITE_WORKERS_SERVICE_URL,
   paramsSerializer: (params) => qs.stringify(params, { indices: false }),
 });
-workerInstance.interceptors.request.use(
-  (config) => {
-    const token = useJwtFromCookie('accessToken');
-    const { t } = useTranslation();
-    if (token) {
-      config.headers.Authorization = `${t('auth0.Bearer')} ${token}`;
-    }
 
+workerInstance.interceptors.request.use(
+  async (config) => {
+    const token = await getTokenSilently();
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
     return config;
   },
   (error) => {

--- a/src/auth0/authUtils.tsx
+++ b/src/auth0/authUtils.tsx
@@ -1,0 +1,33 @@
+import { createAuth0Client } from '@auth0/auth0-spa-js';
+
+const auth0_domain = import.meta.env.VITE_AUTH0_DOMAIN;
+const auth0_client_id = import.meta.env.VITE_AUTH0_CLIENT_ID;
+const auth0_audience = import.meta.env.VITE_AUTH0_AUDIENCE;
+
+const getAuth0Client = () => {
+  return new Promise((resolve, reject) => {
+    let client;
+    if (!client) {
+      try {
+        client = createAuth0Client({
+          domain: auth0_domain,
+          clientId: auth0_client_id,
+          authorizationParams: {
+            redirect_uri: window.location.origin,
+            audience: auth0_audience,
+            scope: 'read:current_user update:current_user_metadata',
+          },
+        });
+        resolve(client);
+      } catch (e) {
+        console.log(e);
+        reject(new Error('getAuth0Client Error'));
+      }
+    }
+  });
+};
+
+export const getTokenSilently = async (...p: any[]) => {
+  const client: any = await getAuth0Client();
+  return await client.getTokenSilently(...p);
+};


### PR DESCRIPTION
בוצע שינוי במערכת כך שהטוקן כבר לא נשמר בקוקי,
אלא נשלף כעת בכל פעם מ-Auth0 באמצעות הפונקציה getTokenSilently.
 שינוי זה מבטיח שהטוקן מתקבל בצורה מאובטחת ומעודכנת בכל בקשה,
 במקום להסתמך על אחסון מקומי.